### PR TITLE
Update GHA

### DIFF
--- a/.github/workflows/build_docker_image.yaml
+++ b/.github/workflows/build_docker_image.yaml
@@ -28,27 +28,27 @@ jobs:
 
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ inputs.free_disk_space || (github.event_name == 'release' && github.event.action == 'published') || github.ref_type == 'tag' }}
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
           android: true
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/build_publish_scan.yaml
+++ b/.github/workflows/build_publish_scan.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Free Disk Space (Ubuntu)
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        if: ${{ github.ref_type == 'tag' }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
@@ -46,10 +46,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ github.event_name == 'release' && github.event.action == 'published' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          sbom: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          sbom: ${{ github.ref_type == 'tag' }}
       - name: Run Trivy vulnerability scanner
-        if: github.event_name != 'release'
+        if: github.ref_type != 'tag'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
@@ -57,8 +57,9 @@ jobs:
           output: 'trivy-results.json'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
       - name: Display vulnerability summary and fail on CRITICAL
-        if: always() && github.event_name != 'release'
+        if: always() && github.ref_type != 'tag'
         run: |
+          set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
           jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build_publish_scan.yaml
+++ b/.github/workflows/build_publish_scan.yaml
@@ -1,0 +1,69 @@
+#v2026.04.10
+# Supports multiplatform (amd64+arm64) on release, single platform otherwise. Max image size ~14GB.
+name: Build, Publish and Scan (Managed)
+on:
+  workflow_call:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+jobs:
+  build-push-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ github.event_name == 'release' && github.event.action == 'published' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          sbom: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+      - name: Run Trivy vulnerability scanner
+        if: github.event_name != 'release'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          format: 'json'
+          output: 'trivy-results.json'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+      - name: Display vulnerability summary and fail on CRITICAL
+        if: always() && github.event_name != 'release'
+        run: |
+          echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
+          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
+          echo "" | tee -a $GITHUB_STEP_SUMMARY
+          echo "To see full details, run: trivy image ${{ fromJSON(steps.meta.outputs.json).tags[0] }}" | tee -a $GITHUB_STEP_SUMMARY
+          if jq -e '.Results[]? | select(.Vulnerabilities) | .Vulnerabilities[] | select(.Severity == "CRITICAL")' trivy-results.json > /dev/null; then
+            echo "::error::CRITICAL vulnerabilities found! Build failed."
+            exit 1
+          fi

--- a/.github/workflows/build_publish_scan.yaml
+++ b/.github/workflows/build_publish_scan.yaml
@@ -14,9 +14,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Free Disk Space (Ubuntu)
         if: ${{ github.ref_type == 'tag' }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -29,18 +29,18 @@ jobs:
           docker-images: true
           swap-storage: true
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/two_step_build_publish_scan.yaml
+++ b/.github/workflows/two_step_build_publish_scan.yaml
@@ -19,10 +19,10 @@ jobs:
       image-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ github.ref_type == 'tag' }}
@@ -37,7 +37,7 @@ jobs:
           swap-storage: true
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,12 +45,12 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -68,7 +68,7 @@ jobs:
       packages: read
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/two_step_build_publish_scan.yaml
+++ b/.github/workflows/two_step_build_publish_scan.yaml
@@ -1,0 +1,99 @@
+#v2026.04.10
+# Supports multiplatform (amd64+arm64) on release, single platform otherwise. Max image size ~14GB.
+name: Two Step Build, Publish and Scan (Managed)
+
+on:
+  workflow_call:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ github.event_name == 'release' && github.event.action == 'published' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          sbom: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+
+  scan:
+    needs: build-push
+    if: github.event_name != 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image
+        run: docker pull ${{ needs.build-push.outputs.image-tag }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ needs.build-push.outputs.image-tag }}
+          format: 'json'
+          output: 'trivy-results.json'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+
+      - name: Display vulnerability summary and fail on CRITICAL
+        if: always()
+        run: |
+          echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
+          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
+          echo "" | tee -a $GITHUB_STEP_SUMMARY
+          echo "To see full details, run: trivy image ${{ needs.build-push.outputs.image-tag }}" | tee -a $GITHUB_STEP_SUMMARY
+
+          if jq -e '.Results[]? | select(.Vulnerabilities) | .Vulnerabilities[] | select(.Severity == "CRITICAL")' trivy-results.json > /dev/null; then
+            echo "::error::CRITICAL vulnerabilities found! Build failed."
+            exit 1
+          fi

--- a/.github/workflows/two_step_build_publish_scan.yaml
+++ b/.github/workflows/two_step_build_publish_scan.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
-          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
+          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | sort_by(.Severity) | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY
           echo "To see full details, run: trivy image ${{ needs.build-push.outputs.image-tag }}" | tee -a $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/two_step_build_publish_scan.yaml
+++ b/.github/workflows/two_step_build_publish_scan.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Free Disk Space (Ubuntu)
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        if: ${{ github.ref_type == 'tag' }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
@@ -56,12 +56,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ github.event_name == 'release' && github.event.action == 'published' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          sbom: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          sbom: ${{ github.ref_type == 'tag' }}
 
   scan:
     needs: build-push
-    if: github.event_name != 'release'
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -88,6 +88,7 @@ jobs:
       - name: Display vulnerability summary and fail on CRITICAL
         if: always()
         run: |
+          set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
           jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ On non-release builds, a vulnerability report is written to the GitHub Actions j
 
 ## Runtime Input
 
-When triggering manually via `workflow_dispatch`, one input is available:
+When triggering manually via `workflow_dispatch`, the **(Customizable)** templates expose one input:
 
 | Input | Description | Default |
 |---|---|---|
 | `free_disk_space` | Frees disk space before the build (~1-2 min overhead). Useful for large images. | `false` |
+
+The **(Managed)** templates support `workflow_dispatch` for manual re-runs but expose no inputs.
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Build Publish and Scan Workflow Templates
-* [build_publish_scan.yaml](build_publish_scan.yaml)
-* [two_step_build_publish_scan.yaml](two_step_build_publish_scan.yaml)
+
+Four templates are available. Pick one:
+
+| Template | File | Best for |
+|---|---|---|
+| Build, Publish and Scan (Customizable) | [build_publish_scan.yaml](workflow-templates/build_publish_scan.yaml) | Teams that want to tweak branches, platforms, failure thresholds, etc. |
+| Two Step Build, Publish and Scan (Customizable) | [two_step_build_publish_scan.yaml](workflow-templates/two_step_build_publish_scan.yaml) | Same as above but scan runs as a separate job |
+| Build, Publish and Scan (Managed) | [build_publish_scan_managed.yaml](workflow-templates/build_publish_scan_managed.yaml) | Teams that want zero maintenance — updates automatically from upstream |
+| Two Step Build, Publish and Scan (Managed) | [two_step_build_publish_scan_managed.yaml](workflow-templates/two_step_build_publish_scan_managed.yaml) | Same as above but scan runs as a separate job |
+
+**Customizable** templates are copied into your repo. You own the file and can edit it freely, but you are responsible for pulling in future updates manually.
+
+**Managed** templates are thin wrappers that call a reusable workflow hosted in this repo. They cannot be customized, but they automatically pick up any updates made to `BERDataLakehouse/.github` — no action required on your part.
 
 A GitHub Actions workflow template that you can install across this org, that will build a Docker image, push it to GitHub Container Registry (ghcr.io), and scan it for vulnerabilities with trivy.
 
@@ -38,6 +49,8 @@ When triggering manually via `workflow_dispatch`, one input is available:
 | `free_disk_space` | Frees disk space before the build (~1-2 min overhead). Useful for large images. | `false` |
 
 ## Customization
+
+> This section applies to the **(Customizable)** templates only. Managed templates cannot be customized.
 
 Since this is a template you own, the expected flow is to edit the file directly after installing it. Common things to adjust:
 

--- a/workflow-templates/build_docker_image.yaml
+++ b/workflow-templates/build_docker_image.yaml
@@ -42,7 +42,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Free Disk Space (Ubuntu)
-        if: ${{ (github.event_name == 'release' && github.event.action == 'published') || github.ref_type == 'tag' }}
+        if: ${{ (github.ref_type == 'tag') || github.ref_type == 'tag' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -55,5 +55,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ github.event_name == 'release' && github.event.action == 'published' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          sbom: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+          platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          sbom: ${{ github.ref_type == 'tag' }}

--- a/workflow-templates/build_docker_image.yaml
+++ b/workflow-templates/build_docker_image.yaml
@@ -23,33 +23,33 @@ jobs:
 
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ github.ref_type == 'tag' }}
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
         with:
           tool-cache: false
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/workflow-templates/build_docker_image.yaml
+++ b/workflow-templates/build_docker_image.yaml
@@ -42,7 +42,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Free Disk Space (Ubuntu)
-        if: ${{ (github.ref_type == 'tag') || github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false

--- a/workflow-templates/build_publish_scan.properties.json
+++ b/workflow-templates/build_publish_scan.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Build, Publish and Scan v2026.04.10",
+    "name": "Build, Publish and Scan (Customizable) v2026.04.10",
     "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-02-23.",
     "iconName": "docker",
     "categories": [

--- a/workflow-templates/build_publish_scan.properties.json
+++ b/workflow-templates/build_publish_scan.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Build, Publish and Scan (Customizable) v2026.04.10",
-    "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-02-23.",
+    "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-04-10.",
     "iconName": "docker",
     "categories": [
         "Deployment",

--- a/workflow-templates/build_publish_scan.properties.json
+++ b/workflow-templates/build_publish_scan.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Build, Publish and Scan (Customizable) v2026.04.10",
-    "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-04-10.",
+    "description": "Build ghcr.io image; scan with Trivy on non-release builds. Multi-architecture on release. Last updated 2026-04-10.",
     "iconName": "docker",
     "categories": [
         "Deployment",

--- a/workflow-templates/build_publish_scan.yaml
+++ b/workflow-templates/build_publish_scan.yaml
@@ -70,6 +70,7 @@ jobs:
       - name: Display vulnerability summary and fail on CRITICAL
         if: always() && github.event_name != 'release'
         run: |
+          set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
           jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY

--- a/workflow-templates/build_publish_scan.yaml
+++ b/workflow-templates/build_publish_scan.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
-          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
+          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | sort_by(.Severity) | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY
           echo "To see full details, run: trivy image ${{ fromJSON(steps.meta.outputs.json).tags[0] }}" | tee -a $GITHUB_STEP_SUMMARY
           if jq -e '.Results[]? | select(.Vulnerabilities) | .Vulnerabilities[] | select(.Severity == "CRITICAL")' trivy-results.json > /dev/null; then

--- a/workflow-templates/build_publish_scan.yaml
+++ b/workflow-templates/build_publish_scan.yaml
@@ -1,6 +1,6 @@
 #v2026.04.10
 # Supports multiplatform (amd64+arm64) on release, single platform otherwise. Max image size ~14GB.
-name: Build and Push Docker Image (Customizable)
+name: Build, Publish and Scan Docker Image (Customizable)
 on:
   workflow_dispatch:
     inputs:

--- a/workflow-templates/build_publish_scan.yaml
+++ b/workflow-templates/build_publish_scan.yaml
@@ -1,6 +1,6 @@
 #v2026.04.10
 # Supports multiplatform (amd64+arm64) on release, single platform otherwise. Max image size ~14GB.
-name: Build and Push Docker Image
+name: Build and Push Docker Image (Customizable)
 on:
   workflow_dispatch:
     inputs:

--- a/workflow-templates/build_publish_scan.yaml
+++ b/workflow-templates/build_publish_scan.yaml
@@ -25,9 +25,9 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Free Disk Space (Ubuntu)
         if: ${{ inputs.free_disk_space || (github.event_name == 'release' && github.event.action == 'published') }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
@@ -40,18 +40,18 @@ jobs:
           docker-images: true
           swap-storage: true
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/workflow-templates/build_publish_scan_managed.properties.json
+++ b/workflow-templates/build_publish_scan_managed.properties.json
@@ -1,0 +1,12 @@
+{
+    "name": "Build, Publish and Scan (Managed)",
+    "description": "Build ghcr.io image and scan with Trivy. Managed by upstream — updates automatically when BERDataLakehouse/.github changes.",
+    "iconName": "docker",
+    "categories": [
+        "Deployment",
+        "Docker"
+    ],
+    "filePatterns": [
+        "Dockerfile"
+    ]
+}

--- a/workflow-templates/build_publish_scan_managed.yaml
+++ b/workflow-templates/build_publish_scan_managed.yaml
@@ -1,0 +1,12 @@
+name: Build, Publish and Scan (Managed)
+on:
+  push:
+    branches: ["main", "master", "develop"]
+  pull_request:
+    branches: ["main", "master", "develop"]
+  release:
+    types: [published]
+jobs:
+  build-publish-scan:
+    uses: BERDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
+    secrets: inherit

--- a/workflow-templates/build_publish_scan_managed.yaml
+++ b/workflow-templates/build_publish_scan_managed.yaml
@@ -9,4 +9,6 @@ on:
 jobs:
   build-publish-scan:
     uses: BERDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
-    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/workflow-templates/build_publish_scan_managed.yaml
+++ b/workflow-templates/build_publish_scan_managed.yaml
@@ -1,5 +1,6 @@
 name: Build, Publish and Scan (Managed)
 on:
+  workflow_dispatch:
   push:
     branches: ["main", "master", "develop"]
   pull_request:

--- a/workflow-templates/two_step_build_publish_scan.properties.json
+++ b/workflow-templates/two_step_build_publish_scan.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Two Step Build, Publish and Scan (Customizable) v2026.04.10",
-    "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-04-10.",
+    "description": "Build ghcr.io image and scan with Trivy on non-release builds. Multi-architecture on release. Last updated 2026-04-10.",
     "iconName": "docker",
     "categories": [
         "Deployment",

--- a/workflow-templates/two_step_build_publish_scan.properties.json
+++ b/workflow-templates/two_step_build_publish_scan.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Two Step Build, Publish and Scan v2026.04.10",
+    "name": "Two Step Build, Publish and Scan (Customizable) v2026.04.10",
     "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-02-23.",
     "iconName": "docker",
     "categories": [

--- a/workflow-templates/two_step_build_publish_scan.properties.json
+++ b/workflow-templates/two_step_build_publish_scan.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Two Step Build, Publish and Scan (Customizable) v2026.04.10",
-    "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-02-23.",
+    "description": "Build ghcr.io image and scan with Trivy. Multi-architecture on release.  Last updated 2026-04-10.",
     "iconName": "docker",
     "categories": [
         "Deployment",

--- a/workflow-templates/two_step_build_publish_scan.yaml
+++ b/workflow-templates/two_step_build_publish_scan.yaml
@@ -1,6 +1,6 @@
 #v2026.04.10
 # Supports multiplatform (amd64+arm64) on release, single platform otherwise. Max image size ~14GB.
-name: Two step build publish and scan docker image
+name: Two Step Build, Publish and Scan (Customizable)
 
 on:
   workflow_dispatch:

--- a/workflow-templates/two_step_build_publish_scan.yaml
+++ b/workflow-templates/two_step_build_publish_scan.yaml
@@ -99,6 +99,7 @@ jobs:
       - name: Display vulnerability summary and fail on CRITICAL
         if: always()
         run: |
+          set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
           jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY

--- a/workflow-templates/two_step_build_publish_scan.yaml
+++ b/workflow-templates/two_step_build_publish_scan.yaml
@@ -30,10 +30,10 @@ jobs:
       image-tag: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Free Disk Space (Ubuntu)
         if: ${{ inputs.free_disk_space || (github.event_name == 'release' && github.event.action == 'published') }}
@@ -48,7 +48,7 @@ jobs:
           swap-storage: true
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -56,12 +56,12 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -79,7 +79,7 @@ jobs:
       packages: read
     steps:
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/workflow-templates/two_step_build_publish_scan.yaml
+++ b/workflow-templates/two_step_build_publish_scan.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           set -o pipefail
           echo "## Vulnerability Summary" | tee -a $GITHUB_STEP_SUMMARY
-          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
+          jq -r '.Results[]? | select(.Vulnerabilities) | "### \(.Target) (\(.Type))", (.Vulnerabilities | sort_by(.Severity) | group_by(.Severity) | map("\(.[0].Severity): \(length)") | .[])' trivy-results.json | tee -a $GITHUB_STEP_SUMMARY || echo "No vulnerabilities found" | tee -a $GITHUB_STEP_SUMMARY
           echo "" | tee -a $GITHUB_STEP_SUMMARY
           echo "To see full details, run: trivy image ${{ needs.build-push.outputs.image-tag }}" | tee -a $GITHUB_STEP_SUMMARY
 

--- a/workflow-templates/two_step_build_publish_scan_managed.properties.json
+++ b/workflow-templates/two_step_build_publish_scan_managed.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "Two Step Build, Publish and Scan (Managed)",
-    "description": "Two-job build ghcr.io image and scan with Trivy. Managed by upstream — updates automatically when BERDataLakehouse/.github changes.",
+    "description": "Two-step build, publish ghcr.io image, and scan with Trivy. Managed by upstream — updates automatically when BERDataLakehouse/.github changes.",
     "iconName": "docker",
     "categories": [
         "Deployment",

--- a/workflow-templates/two_step_build_publish_scan_managed.properties.json
+++ b/workflow-templates/two_step_build_publish_scan_managed.properties.json
@@ -1,0 +1,12 @@
+{
+    "name": "Two Step Build, Publish and Scan (Managed)",
+    "description": "Two-job build ghcr.io image and scan with Trivy. Managed by upstream — updates automatically when BERDataLakehouse/.github changes.",
+    "iconName": "docker",
+    "categories": [
+        "Deployment",
+        "Docker"
+    ],
+    "filePatterns": [
+        "Dockerfile"
+    ]
+}

--- a/workflow-templates/two_step_build_publish_scan_managed.yaml
+++ b/workflow-templates/two_step_build_publish_scan_managed.yaml
@@ -9,4 +9,6 @@ on:
 jobs:
   two-step-build-publish-scan:
     uses: BERDataLakehouse/.github/.github/workflows/two_step_build_publish_scan.yaml@main
-    secrets: inherit
+    permissions:
+      contents: read
+      packages: write

--- a/workflow-templates/two_step_build_publish_scan_managed.yaml
+++ b/workflow-templates/two_step_build_publish_scan_managed.yaml
@@ -1,5 +1,6 @@
 name: Two Step Build, Publish and Scan (Managed)
 on:
+  workflow_dispatch:
   push:
     branches: ["main", "master", "develop"]
   pull_request:

--- a/workflow-templates/two_step_build_publish_scan_managed.yaml
+++ b/workflow-templates/two_step_build_publish_scan_managed.yaml
@@ -1,0 +1,12 @@
+name: Two Step Build, Publish and Scan (Managed)
+on:
+  push:
+    branches: ["main", "master", "develop"]
+  pull_request:
+    branches: ["main", "master", "develop"]
+  release:
+    types: [published]
+jobs:
+  two-step-build-publish-scan:
+    uses: BERDataLakehouse/.github/.github/workflows/two_step_build_publish_scan.yaml@main
+    secrets: inherit


### PR DESCRIPTION

 # Summary

  - Add two managed workflow templates (build_publish_scan_managed.yaml, two_step_build_publish_scan_managed.yaml) — thin wrappers that
   delegate to reusable workflows hosted in this repo. Users who install these get automatic updates whenever .github changes; no copy
  to maintain.
  - Add two reusable workflows (.github/workflows/build_publish_scan.yaml, .github/workflows/two_step_build_publish_scan.yaml) — the
  upstream source of truth called by the managed templates. Use github.ref_type == 'tag' instead of github.event_name == 'release' so
  release-specific behavior (multi-arch, SBOM, disk cleanup, scan skip) works correctly under workflow_call.
  - Rename existing templates to "(Customizable)" to make the distinction clear in the Actions UI.
  - Security hardening across all workflows:
    - Pin all third-party actions to commit SHAs (no versioned tags or floating @main)
    - Add set -o pipefail to vulnerability summary scripts so jq failures surface correctly
    - Explicit permissions: contents: read / packages: write on managed template calling jobs
    - Remove secrets: inherit from managed templates — GITHUB_TOKEN is forwarded automatically

# Test plan

  - Install build_publish_scan_managed.yaml in a test repo and verify push, PR, release, and manual dispatch all trigger correctly
  - Publish a release on a test repo and confirm multi-arch build, SBOM generation, and disk cleanup all run — and that the Trivy scan is skipped
  - Verify a non-release build runs Trivy and fails on a CRITICAL CVE
  - Update a reusable workflow in .github and confirm the change propagates to a repo using a managed template without any changes on
  their side