### PR TITLE
Instruct the user to give package write perms to the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Four templates are available. Pick one:
 A GitHub Actions workflow template that you can install across this org, that will build a Docker image, push it to GitHub Container Registry (ghcr.io), and scan it for vulnerabilities with trivy.
 
 ## Installation
-Click on "actions" -> new workflow -> choose the workflow
+* Click on "actions" -> new workflow -> choose the workflow
+* Click on the repo package -> Package settings -> Manage Actions access -> Give the repo `Write` permissions
 
 ## Triggers
 


### PR DESCRIPTION
Otherwise in GHA you get

```
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to push ghcr.io/kbase/cdm-task-service:pr-596: denied: permission_denied: write_package
```